### PR TITLE
fix parser if vlan config is on multiple lines

### DIFF
--- a/plugins/module_utils/network/os6.py
+++ b/plugins/module_utils/network/os6.py
@@ -195,6 +195,10 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'(tacacs-server) host.*$')]
 
     childline = re.compile(r'^exit\s*$')
+
+    # bring vlan config to one single line
+    lines = re.sub("(?<=vlan )([0-9,-]+)\nvlan ", "\\1,", lines, 0, re.MULTILINE)
+
     config = list()
     parent = list()
     children = []


### PR DESCRIPTION
##### SUMMARY
Bring multiple vlan config lines to one single line. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os6.py: os6_parse()

##### ADDITIONAL INFORMATION
The dell switch with OS6 wrap the vlan config to multiple lines if there are a lot of vlans configured. Ansible leads always into a changed status because the comparison between running-config an the new config will not work well.

The fix brings the code in the variable "line" from
```
!System Software Version 6.7.1.17
!
configure
vlan 2,5,11-13,18,24,35-36,38,40,42,44,46-48,53-55,101,240,1902-1903,1909
vlan 2001-2003
vlan 2007,2300
exit
vlan 2

```
to
```
!System Software Version 6.7.1.17
!
configure
vlan 2,5,11-13,18,24,35-36,38,40,42,44,46-48,53-55,101,240,1902-1903,1909,2001-2003,2007,2300
exit
vlan 2

```